### PR TITLE
README: use syntax highlighting and markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,65 +4,64 @@
 
 Token Replacer is a simple and small Java Library that helps replacing tokens in strings.
 
-You can replace tokens with <b>simple static strings</b>:
-	
-	String toReplace = "i can count to {number}";
-    String result = new Toky().register("number", "123").substitute(toReplace);
-    System.out.println(result); // i can count to 123
-
-or strings generated <b>"on-the-fly"</b>: 
-	
-	String toReplace = "i can count to {number}";
-    String result = new Toky().register(new Token("number").replacedBy(new Generator() {
+You can replace tokens with **simple static strings**:
+```Java
+String toReplace = "i can count to {number}";
+String result = new Toky().register("number", "123").substitute(toReplace);
+System.out.println(result); // i can count to 123
+```
+or strings generated **"on-the-fly"**: 
+```Java
+String toReplace = "i can count to {number}";
+String result = new Toky().register(new Token("number").replacedBy(new Generator() {
     
-        @Override
-        public void inject(String[] args) {
-            // store the arguments
-        }
-        
-        @Override
-        public String generate() {
-            return "123"; // some very sophisticated stuff happens here :), we just return 123 to keep it simple^
-        }
-     })).substitute(toReplace);
-     System.out.println(result); // i can count to 123
+	@Override
+	public void inject(String[] args) {
+	    // store the arguments
+	}
 
-You can even <b>pass arguments</b> to the generator which makes it pretty powerful:
-	
-	String toReplace = "i can count to {number(1,2,3)}";
-    String result = new Toky().register(new Token("number").replacedBy(new Generator() {
+	@Override
+	public String generate() {
+	    return "123"; // some very sophisticated stuff happens here :), we just return 123 to keep it simple
+	}
+})).substitute(toReplace);
+System.out.println(result); // i can count to 123
+```
+You can even **pass arguments** to the generator which makes it pretty powerful:
+```Java
+String toReplace = "i can count to {number(1,2,3)}";
+String result = new Toky().register(new Token("number").replacedBy(new Generator() {
     
-        @Override
-        public void inject(String[] args) {
-            // store the arguments
-        }
-        
-        @Override
-        public String generate() {
-            return args[0] + args[1] + args[2]; // some very sophisticated stuff happens here :)
-        }
-     })).substitute(toReplace);
-     System.out.println(result); // i can count to 123
+	@Override
+	public void inject(String[] args) {
+	    // store the arguments
+	}
 
-If you prefer to use <b>index based tokens</b>, you can also use this:
- 
-<pre>
-toky.register(new String[] { &quot;one&quot;, &quot;two&quot;, &quot;three&quot; });
-toky.substitute(&quot;abc {0} {1} {2} def&quot;)); // will produce &quot;abc one two three def&quot;
-</pre>
-   
+	@Override
+	public String generate() {
+	    return args[0] + args[1] + args[2]; // some very sophisticated stuff happens here :)
+	}
+})).substitute(toReplace);
+System.out.println(result); // i can count to 123
+```
+If you prefer to use **index based tokens**, you can also use this:
+```Java
+toky.register(new String[] { "one", "two", "three" });
+toky.substitute("abc {0} {1} {2} def"); // will produce "abc one two three def";
+```
+
 ## Getting the Jar File
 
 via Maven:
-
-    <dependency>
-        <groupId>de.marcelsauer</groupId>
-        <artifactId>tokenreplacer</artifactId>
-        <version>1.3.2</version>
-    </dependency>
-
+```
+<dependency>
+    <groupId>de.marcelsauer</groupId>
+    <artifactId>tokenreplacer</artifactId>
+    <version>1.3.2</version>
+</dependency>
+```
 or just take the latest "tokenreplacer-x.y.jar" from the [downloads](http://github.com/niesfisch/tokenreplacer/downloads) section and put it in your classpath.
-if you also need the sources and javadoc download the "tokenreplacer-x.y-sources.jar" / "tokenreplacer-x.y-javadoc.jar".
+If you also need the sources and javadoc download the "tokenreplacer-x.y-sources.jar" / "tokenreplacer-x.y-javadoc.jar".
 
 ## Licence
 
@@ -76,103 +75,88 @@ Version <= 1.1 -> GPL 3
         
 ## Usage
 
-<p>
-simplest use case, only <b>static values</b>
-</p>
+simplest use case, only **static values**
 
-<pre>
-TokenReplacer toky = new Toky().register(&quot;number&quot;, &quot;123&quot;);
-toky.substitute(&quot;i can count to {number}&quot;);
-</pre>
+```Java
+TokenReplacer toky = new Toky().register("number", "123");
+toky.substitute("i can count to {number}");
+```
 
-<p>
-is same as registering an <b>explicit {@link Token}</b>
-</p>
+is same as registering an **explicit {@link Token}**
 
-<pre>
-toky = new Toky().register(new Token(&quot;number&quot;).replacedBy(&quot;123&quot;));
-toky.substitute(&quot;i can count to {number}&quot;);
-</pre>
+```Java
+toky = new Toky().register(new Token("number").replacedBy("123"));
+toky.substitute("i can count to {number}");
+```
 
-<p>
-we can also use a <b>{@link Generator}</b> to <b>dynamically</b> get the
-value (which here does not really make sense ;-)
-</p>
+we can also use a **{@link Generator}** to **dynamically** get the
+value (which here does not really make sense ;-))
 
-<pre>
-toky = new Toky().register(new Token(&quot;number&quot;).replacedBy(new Generator() {
+```Java
+toky = new Toky().register(new Token("number").replacedBy(new Generator() {
 
- &#064;Override
- public void inject(String[] args) {
-     // not relevant here
- }
+	 @Override
+	 public void inject(String[] args) {
+	     // not relevant here
+	 }
 
- &#064;Override
- public String generate() {
-     return &quot;123&quot;;
- }
+	 @Override
+	 public String generate() {
+	     return "123";
+	 }
 }));
-</pre>
-<p>
-here we use a generator and <b>pass the arguments</b> "a,b,c" to it, they
+```
+
+here we use a generator and **pass the arguments** "a,b,c" to it, they
 will be injected via {@link Generator#inject(String[] args)} before the call
 to {@link Generator#generate()} is done. it is up to the generator to decide
 what to do with them. this feature makes handling tokens pretty powerful
 because you can write very dynamic generators.
-</p>
 
-<pre>
-toky.substitute(&quot;i can count to {number(a,b,c)}&quot;);
-</pre>
+```Java
+toky.substitute("i can count to {number(a,b,c)}");
+```
 
-if you prefer to use <b>index based tokens</b>, you can also use this:
+if you prefer to use **index based tokens**, you can also use this:
  
-<pre>
-toky.register(new String[] { &quot;one&quot;, &quot;two&quot;, &quot;three&quot; });
-toky.substitute(&quot;abc {0} {1} {2} def&quot;)); // will produce &quot;abc one two three def&quot;
-</pre>
- 
-<p>
-of course you can replace all default <b>delimiters</b> with your preferred
+```Java
+toky.register(new String[] { "one", "two", "three" });
+toky.substitute("abc {0} {1} {2} def"); // will produce "abc one two three def";
+```
+
+of course you can replace all default **delimiters** with your preferred
 ones, just make sure start and end are different.
-</p>
 
-<pre>
-toky.withTokenStart(&quot;*&quot;); // default is '{'
-toky.withTokenEnd(&quot;#&quot;); // default is '}'
-toky.withArgumentDelimiter(&quot;;&quot;); // default is ','
-toky.withArgumentStart(&quot;[&quot;); // default is '('
-toky.withArgumentEnd(&quot;]&quot;); // default is ')'
-</pre>
+```Java
+toky.withTokenStart("*"); // default is '{'
+toky.withTokenEnd("#"); // default is '}'
+toky.withArgumentDelimiter(";"); // default is ','
+toky.withArgumentStart("["); // default is '('
+toky.withArgumentEnd("]"); // default is ')'
+```
 
-<p>
 by default Toky will throw IllegalStateExceptions if there was no matching
-value or generator found for a token. you can <b>enable/disable generating
-exceptions</b>.
-</p>
+value or generator found for a token. you can **enable/disable generating
+exceptions**.
 
-<pre>
+```Java
 toky.doNotIgnoreMissingValues(); // which is the DEFAULT
-</pre>
+```
 
-<p>
 will turn error reporting for missing values <b>OFF</b>
-</p>
 
-<pre>
+```Java
 toky.ignoreMissingValues();
-</pre>
+```
 
-<p>
-you can <b>enable/disable generator caching</b>. if you enable caching once a
+you can **enable/disable generator caching**. if you enable caching once a
 generator for a token returned a value this value will be used for all
 subsequent tokens with the same name
-</p>
 
-<pre>
+```Java
 toky.enableGeneratorCaching();
 toky.disableGeneratorCaching();
-</pre>
+```
 
 
 ## More Samples
@@ -184,4 +168,4 @@ Have a look at [the unit test of Toky](http://github.com/niesfisch/tokenreplacer
     $ git clone http://github.com/niesfisch/tokenreplacer.git tokenreplacer
     $ cd tokenreplacer
     $ mvn clean install
-    
+


### PR DESCRIPTION
This adds Github's markdown capabilities of syntax highlighting in code snippets.
Furthermore, it replaces html elements with the markdown equivalent, so that we
don't have to deal with html escape characters, like &quot;.

We might rework this though, if you generate the README from your source code automatically. I'm not familiar with your build process in that regard. 🙈